### PR TITLE
Add `minimum_time` to iter requests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,8 @@ Changelog
 dev
 ```
 
+* Add ``minimum_time`` argument to ``SlackAPI.iter`` in order to force a minimum elapsed time between two call to the API
+
 0.3.2
 `````
 


### PR DESCRIPTION
Fix #24

This param force an elapsed time between calls to the slack API
during iterative request in order to not trigger the rate limiting