### PR TITLE
Fix bug related to slack command response

### DIFF
--- a/slack/sansio.py
+++ b/slack/sansio.py
@@ -61,7 +61,7 @@ def raise_for_api_error(headers, data):
     Raises:
         :class:`slack.exceptions.SlackAPIError`
     """
-    if not data["ok"]:
+    if not (data == 'ok' or data['ok']):  # There is one api that just returns "ok" instead of json
         raise exceptions.SlackAPIError(data.get("error", "unknow_error"), headers, data)
 
     if "warning" in data:


### PR DESCRIPTION
The api for slack command ephemeral responses returns "ok" instead of the json response all slack api's are supposed to return. This change allows both to work.