### PR TITLE
Add support for block-type slack actions

### DIFF
--- a/slack/tests/conftest.py
+++ b/slack/tests/conftest.py
@@ -21,7 +21,6 @@ try:
 except ImportError:
     SlackAPIRequest = None  # type: ignore
 
-
 TOKEN = "abcdefg"
 
 
@@ -192,6 +191,13 @@ def action(request):
         payload = copy.deepcopy(request.param)
 
     return payload
+
+
+@pytest.fixture(params={
+    **data.BlockAction.__members__  # type: ignore
+})
+def block_action(request):
+    return copy.deepcopy(data.BlockAction[request.param].value)
 
 
 # @pytest.fixture(params={**data.InteractiveMessage.__members__})

--- a/slack/tests/conftest.py
+++ b/slack/tests/conftest.py
@@ -193,9 +193,7 @@ def action(request):
     return payload
 
 
-@pytest.fixture(params={
-    **data.BlockAction.__members__  # type: ignore
-})
+@pytest.fixture(params={**data.BlockAction.__members__})  # type: ignore
 def block_action(request):
     return copy.deepcopy(data.BlockAction[request.param].value)
 

--- a/slack/tests/data/__init__.py
+++ b/slack/tests/data/__init__.py
@@ -1,9 +1,7 @@
 from .events import Events, Messages, RTMEvents  # noQa F401
-from .actions import (
-    MessageAction,
-    DialogSubmission,
-    InteractiveMessage,
-    BlockAction,
-)  # noQa F401
+from .actions import BlockAction  # noQa F401
+from .actions import MessageAction  # noQa F401
+from .actions import DialogSubmission  # noQa F401
+from .actions import InteractiveMessage  # noQa F401
 from .methods import Methods  # noQa F401
 from .commands import Commands  # noQa F401

--- a/slack/tests/data/__init__.py
+++ b/slack/tests/data/__init__.py
@@ -1,4 +1,4 @@
 from .events import Events, Messages, RTMEvents  # noQa F401
-from .actions import MessageAction, DialogSubmission, InteractiveMessage  # noQa F401
+from .actions import MessageAction, DialogSubmission, InteractiveMessage, BlockAction  # noQa F401
 from .methods import Methods  # noQa F401
 from .commands import Commands  # noQa F401

--- a/slack/tests/data/__init__.py
+++ b/slack/tests/data/__init__.py
@@ -1,4 +1,9 @@
 from .events import Events, Messages, RTMEvents  # noQa F401
-from .actions import MessageAction, DialogSubmission, InteractiveMessage, BlockAction  # noQa F401
+from .actions import (
+    MessageAction,
+    DialogSubmission,
+    InteractiveMessage,
+    BlockAction,
+)  # noQa F401
 from .methods import Methods  # noQa F401
 from .commands import Commands  # noQa F401

--- a/slack/tests/data/actions.py
+++ b/slack/tests/data/actions.py
@@ -65,10 +65,40 @@ message_action = {
     "response_url": "https://hooks.slack.com/actions/T000AAA0A/123456789123/YTC81HsJRuuGSLVFbSnlkJlh",
 }
 
+block_action = {
+    "type": "block_actions",
+    "token": "supersecuretoken",
+    "action_ts": "987654321.000001",
+    "team": {"id": "T000AAA0A", "domain": "team"},
+    "user": {"id": "U000AA000", "name": "username"},
+    "channel": {"id": "C00000A00", "name": "general"},
+    "trigger_id": "418799722116.77329528181.9c7441638716b0b9b698f3d8ae73d9c1",
+    "message_ts": "1534605601.000100",
+    "message": {
+        "type": "message",
+        "user": "U000AA000",
+        "text": "test message",
+        "client_msg_id": "904f281d-338e-4621-a56f-afbfc80b3c59",
+        "ts": "1534605601.000100",
+    },
+    "actions": [
+        {
+            "type": "static_select",
+            "block_id": "test_block_id",
+            "action_id": "test_action_id",
+            "selected_option": {"text": {"type": "plain_text", "text": "Edit it"}, "value": "value-0"},
+            "placeholder": {"type": "plain_text", "text": "Manage"},
+            "action_ts": "1557505776.632169"
+        }
+    ],
+    "response_url": "https://hooks.slack.com/actions/T000AAA0A/123456789123/YTC81HsJRuuGSLVFbSnlkJlh",
+}
+
 raw_button_ok = {"payload": json.dumps(button_ok)}
 raw_button_cancel = {"payload": json.dumps(button_cancel)}
 raw_dialog_submission = {"payload": json.dumps(dialog_submission)}
 raw_message_action = {"payload": json.dumps(message_action)}
+raw_block_action = {"payload": json.dumps(block_action)}
 
 
 class InteractiveMessage(Enum):
@@ -103,3 +133,12 @@ class MessageAction(Enum):
     """
 
     action = raw_message_action
+
+
+class BlockAction(Enum):
+    """
+    List of available block action for testing
+
+        - option_select
+    """
+    option_select = raw_block_action

--- a/slack/tests/data/actions.py
+++ b/slack/tests/data/actions.py
@@ -86,9 +86,12 @@ block_action = {
             "type": "static_select",
             "block_id": "test_block_id",
             "action_id": "test_action_id",
-            "selected_option": {"text": {"type": "plain_text", "text": "Edit it"}, "value": "value-0"},
+            "selected_option": {
+                "text": {"type": "plain_text", "text": "Edit it"},
+                "value": "value-0",
+            },
             "placeholder": {"type": "plain_text", "text": "Manage"},
-            "action_ts": "1557505776.632169"
+            "action_ts": "1557505776.632169",
         }
     ],
     "response_url": "https://hooks.slack.com/actions/T000AAA0A/123456789123/YTC81HsJRuuGSLVFbSnlkJlh",
@@ -141,4 +144,5 @@ class BlockAction(Enum):
 
         - option_select
     """
+
     option_select = raw_block_action

--- a/slack/tests/test_actions.py
+++ b/slack/tests/test_actions.py
@@ -85,7 +85,9 @@ class TestActionRouter:
         def handler():
             pass
 
-        action_router.register_block_action("test_block_id", handler, action_id="test_action_id")
+        action_router.register_block_action(
+            "test_block_id", handler, action_id="test_action_id"
+        )
 
         assert len(action_router._routes["test_block_id"]["test_action_id"]) == 1
         assert action_router._routes["test_block_id"]["test_action_id"][0] is handler
@@ -198,7 +200,9 @@ class TestActionRouter:
             pass
 
         act = Action.from_http(block_action)
-        action_router.register_block_action("test_block_id", handler, action_id="test_action_id")
+        action_router.register_block_action(
+            "test_block_id", handler, action_id="test_action_id"
+        )
 
         handlers = list()
         for h in action_router.dispatch(act):


### PR DESCRIPTION
Adds support for Slack's new [Block-based](https://api.slack.com/block-kit) interactive messages.

Additionally, created specific registration methods for each type of action (`interactive_message`, `dialog_submission`, and `block_actions`) with the relevant parameter names and documentation which internally call the base `register` method.